### PR TITLE
Fix date variable in release workflow

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - run: echo "name=date::$(date +'%Y%m%d')"
+      - run: echo "date=$(date +'%Y%m%d')" >> "$GITHUB_OUTPUT"
         id: date
       - run: sudo sh ./scripts/download-builds.sh
         id: builds


### PR DESCRIPTION
To fix #13, I followed the documentation [Setting an output parameter](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter) to fix how `date` was being stored to be used later on at the end of the `tag_name` variable.

I verified it managed to correctly populate that field running the workflow myself:
https://github.com/rob93c/setup-ffmpeg/actions/runs/5084761298/jobs/9137458178#step:5:3

> Run actions/create-release@v1
  with:
    tag_name: ffmpeg-6.0-[2](https://github.com/rob93c/setup-ffmpeg/actions/runs/5084761298/jobs/9137458178#step:5:2)02[3](https://github.com/rob93c/setup-ffmpeg/actions/runs/5084761298/jobs/9137458178#step:5:3)0525
    release_name: FFmpeg Build v6.0
    draft: false
    prerelease: false
  env:
    GITHUB_TOKEN: ***

To me it's not easy to say if that would be enough to fix the issue preventing the download of FFmpeg 6 but it could be a good starting point.