### PR TITLE
fix: Install With Retries

### DIFF
--- a/src/dists/installer.js
+++ b/src/dists/installer.js
@@ -111,7 +111,7 @@ export async function install(options) {
   const toolInstallDir = tc.find(options.toolCacheDir, version, options.arch);
   if (toolInstallDir) {
     core.info(`Using ffmpeg version ${version} from tool cache`);
-    return { version, path: toolInstallDir, cacheHit: true };
+    return {version, path: toolInstallDir, cacheHit: true};
   }
 
   if (!release) {


### PR DESCRIPTION
# Rationale

Recently, I ran into [this issue](https://github.com/federicocarboni/setup-ffmpeg/issues/19). It seems that adding a retry logic might be beneficial to some of the less-reliable network calls.